### PR TITLE
When Radio is ON update subInfoRecord

### DIFF
--- a/src/java/com/android/internal/telephony/uicc/UiccController.java
+++ b/src/java/com/android/internal/telephony/uicc/UiccController.java
@@ -152,6 +152,7 @@ public class UiccController extends Handler {
             mCis[i].registerForIccStatusChanged(this, EVENT_ICC_STATUS_CHANGED, index);
             // TODO remove this once modem correctly notifies the unsols
             mCis[i].registerForNotAvailable(this, EVENT_RADIO_UNAVAILABLE, index);
+            mCis[i].registerForOn(this, EVENT_ICC_STATUS_CHANGED, index);
             if (mOEMHookSimRefresh) {
                 mCis[i].registerForSimRefreshEvent(this, EVENT_REFRESH_OEM, index);
             } else {


### PR DESCRIPTION
Register for radio on to update subInfoRecords in case to handle case
Icc Availability event comes before radio is on.

Change-Id: I5adbe1c92148e0e9f9cf5d908ed69ce788b4ae32
CRs-Fixed: 758818
Signed-off-by: cj360 ayunker551@gmail.com

Conflicts:
    src/java/com/android/internal/telephony/uicc/UiccController.java
